### PR TITLE
Make ~GalilAxis() and ~GalilCSAxis() virtual functions. Fixes compile…

### DIFF
--- a/3-5/GalilSup/src/GalilAxis.h
+++ b/3-5/GalilSup/src/GalilAxis.h
@@ -184,7 +184,7 @@ public:
   asynStatus setClosedLoop(bool closedLoop);
   asynStatus initializeProfile(size_t maxProfilePoints);
 
-  ~GalilAxis();
+  virtual ~GalilAxis();
 
 private:
   GalilController *pC_;      		/**< Pointer to the asynMotorController to which this axis belongs.

--- a/3-5/GalilSup/src/GalilCSAxis.h
+++ b/3-5/GalilSup/src/GalilCSAxis.h
@@ -102,7 +102,7 @@ public:
   asynStatus stop(double acceleration);
   asynStatus initializeProfile(size_t maxProfilePoints);
 
-  ~GalilCSAxis();
+  virtual ~GalilCSAxis();
 
 private:
   GalilController *pC_;      		/**< Pointer to the asynMotorController to which this axis belongs.


### PR DESCRIPTION
…r warning with gcc 4.8.5.

eg:

GalilController.cpp: In member function ‘void GalilController::shutdownController()’:
../GalilController.cpp:804:20: warning: deleting object of polymorphic class type ‘GalilAxis’ which has non-virtual destructor might cause undefined behaviour [-Wdelete-non-virtual-dtor]
             delete pAxis;
                    ^
../GalilController.cpp:810:19: warning: deleting object of polymorphic class type ‘GalilCSAxis’ which has non-virtual destructor might cause undefined behaviour [-Wdelete-non-virtual-dtor]
            delete pCSAxis;
