### PR TITLE
Add ability to use LD command to enable/disable hardware limits. The …

### DIFF
--- a/3-5/GalilSup/Db/galil_motor_extras.template
+++ b/3-5/GalilSup/Db/galil_motor_extras.template
@@ -1004,6 +1004,44 @@ record(ao,"$(P)$(M)_BRAKEONDELAY_SP")
 	field(FLNK, "$(P)$(M)_BRAKEONDELAY_MON")
 }
 
+#Enable/Disable Hardware Limits using LD command
+#The controller still reports the limit switch status 
+#and so in the driver we don't report the limits if 
+#we choose to disable limits using this command.
+record(mbbo,"$(P)$(M)_LIMITDISABLE_CMD")
+{
+	field(DESC, "Limit Disable")
+	field(PINI, "YES")
+	field(DTYP, "asynInt32")
+	field(ZRVL, "0")
+	field(ONVL, "1")
+	field(TWVL, "2")
+	field(THVL, "3")
+	field(ZRST, "Off")
+	field(ONST, "Only Fwd Disabled")
+	field(TWST, "Only Rev Disabled")
+	field(THST, "Both Disabled")
+	field(VAL,  "0")
+	field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_LIMIT_DISABLE")
+	field(FLNK, "$(P)$(M)_LIMITDISABLE_STATUS")
+}
+
+record(mbbi,"$(P)$(M)_LIMITDISABLE_STATUS")
+{
+	field(DESC, "Limit Disable")
+	field(DTYP, "asynInt32")
+	field(SCAN, "$(SCAN)")
+	field(ZRVL, "0")
+	field(ONVL, "1")
+	field(TWVL, "2")
+	field(THVL, "3")
+	field(ZRST, "Off")
+	field(ONST, "Only Fwd Disabled")
+	field(TWST, "Only Rev Disabled")
+	field(THST, "Both Disabled")
+   	field(INP,  "@asyn($(PORT),$(ADDR))MOTOR_LIMIT_DISABLE")
+}
+
 record(bi,"$(P)$(M)_ON_STATUS")
 {
 	field(DESC, "Mtr on status")

--- a/3-5/GalilSup/src/GalilAxis.cpp
+++ b/3-5/GalilSup/src/GalilAxis.cpp
@@ -1316,6 +1316,7 @@ asynStatus GalilAxis::getStatus(void)
    unsigned digport = 0;			//paramList items to update.  Used for brake status
    unsigned mask;				//Mask used to calc brake port status
    int brakeport;				//Brake port for this axis
+   int limitDisable = 0;                        //Limit disabled param
 
    //If data record query success in GalilController::acquireDataRecord
    if (pC_->recstatus_ == asynSuccess)
@@ -1377,14 +1378,20 @@ asynStatus GalilAxis::getStatus(void)
 		//Invert SSI encoder direction
 		if (invert_ssi_)
 			invert_ssi();
+		//Before setting limits, readback limit disable parameter
+		pC_->getIntegerParam(axisNo_, pC_->GalilLimitDisable_, &limitDisable);
 		//reverse limit
 		strcpy(src, "_LRx");
 		src[3] = axisName_;
 		rev_ = (bool)(pC_->sourceValue(pC_->recdata_, src) == 1) ? 0 : 1;
+		if (limitDisable >= 2)
+			rev_ = 0;
 		//forward limit
 		strcpy(src, "_LFx");
 		src[3] = axisName_;
 		fwd_ = (bool)(pC_->sourceValue(pC_->recdata_, src) == 1) ? 0 : 1;
+		if ((limitDisable == 1) || (limitDisable == 3))
+			fwd_ = 0;
 		//home switch
 		strcpy(src, "_HMx");
 		src[3] = axisName_;

--- a/3-5/GalilSup/src/GalilController.h
+++ b/3-5/GalilSup/src/GalilController.h
@@ -155,6 +155,7 @@
 #define GalilHomingString		"MOTOR_HOMING"
 #define GalilUserDataString		"MOTOR_USER_DATA"
 #define GalilUserDataDeadbString	"MOTOR_USER_DATA_DEADB"
+#define GalilLimitDisableString        "MOTOR_LIMIT_DISABLE"
 
 #define GalilMainEncoderString		"MOTOR_MAIN_ENCODER"
 #define GalilAuxEncoderString		"MOTOR_AUX_ENCODER"
@@ -419,6 +420,7 @@ protected:
   int GalilHoming_;
   int GalilUserData_;
   int GalilUserDataDeadb_;
+  int GalilLimitDisable_;
 
   int GalilMainEncoder_;
   int GalilAuxEncoder_;


### PR DESCRIPTION
…driver will ignore hardware limits if we disable the limits, because the controller still reports the limit state even though it doesn't act on them.