### PR TITLE
Add support for building with epics ci-scripts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,119 @@
+# .appveyor.yml for use with EPICS Base ci-scripts
+# (see: https://github.com/epics-base/ci-scripts)
+
+# This is YAML - indentation levels are crucial
+
+#---------------------------------#
+#       build cache               #
+#---------------------------------#
+# The AppVeyor cache allowance is way too small (1GB per account across all projects, branches and jobs)
+# to be used for the dependency builds.
+
+cache:
+  - C:\Users\appveyor\.tools
+
+#---------------------------------#
+#       repository cloning        #
+#---------------------------------#
+
+# Called at very beginning, before repo cloning
+init:
+  # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  # Set autocrlf to make batch files work
+  - git config --global core.autocrlf true
+
+# Set clone depth (do not fetch complete history)
+clone_depth: 50
+
+# Skipping commits affecting only specific files
+skip_commits:
+  files:
+    - 'documentation/*'
+    - 'templates/*'
+    - '**/*.html'
+    - '**/*.md'
+
+#---------------------------------#
+#   build matrix configuration    #
+#---------------------------------#
+# Since dependencies cannot be cached and AppVeyor only grants a single builder VM, all jobs
+# are executed sequentially, each one taking 10-15 minutes.
+# Consider this when defining your build matrix. (A full matrix build takes more than 8 hours.)
+
+# Build Configurations: dll/static, regular/debug
+configuration:
+  - dynamic
+  - static
+  - dynamic-debug
+  - static-debug
+
+# Environment variables: compiler toolchain, base version, setup file, ...
+environment:
+  # common / default variables for all jobs
+  SETUP_PATH: 3-6/.ci-local:3-6/.ci
+  SET: stable
+  VV: 1
+
+  matrix:
+  - CMP: vs2019
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+  - CMP: mingw
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  - CMP: vs2019
+    BASE: 3.15
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+  - CMP: vs2019
+    BASE: 3.14
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+  - CMP: vs2017
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - CMP: vs2015
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  - CMP: vs2013
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+# Platform: architecture
+platform:
+  - x86
+  - x64
+
+#---------------------------------#
+#     building & testing          #
+#---------------------------------#
+
+install:
+# for the sequencer
+  - cinst re2c
+  - cmd: git submodule update --init --recursive
+  - cmd: python 3-6/.ci/appveyor/do.py prepare
+
+build_script:
+  - cmd: python 3-6/.ci/appveyor/do.py build
+
+#test_script:
+#  - cmd: python 3-6/.ci/appveyor/do.py test
+
+#---------------------------------#
+#         debugging               #
+#---------------------------------#
+
+## if you want to connect by remote desktop to a failed build, uncomment these lines
+## note that you will need to connect within the usual build timeout limit (60 minutes)
+## so you may want to adjust the build matrix above to just build the one of interest
+
+#on_failure:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+
+#---------------------------------#
+#         notifications           #
+#---------------------------------#
+
+#notifications:
+#
+#  - provider: Email
+#    to:
+#      - core-talk@aps.anl.gov
+#    on_build_success: false
+
+#  - provider: GitHubPullRequest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3-6/.ci"]
+	path = 3-6/.ci
+	url = https://github.com/epics-base/ci-scripts.git

--- a/3-6/.ci-local/stable.set
+++ b/3-6/.ci-local/stable.set
@@ -1,0 +1,11 @@
+MODULES=sncseq autosave sscan calc ipac asyn busy motor
+
+BASE=3.15
+SNCSEQ=R2-2-8
+AUTOSAVE=R5-10
+SSCAN=R2-11-3
+CALC=R3-7-3
+BUSY=R1-7-2
+IPAC=2.15
+ASYN=master
+MOTOR=R7-1

--- a/3-6/GalilTestApp/src/Makefile
+++ b/3-6/GalilTestApp/src/Makefile
@@ -29,7 +29,10 @@ GalilTest_SRCS_DEFAULT += GalilTestMain.cpp
 
 #add a definition for each support application used by this application
 GalilTest_LIBS += GalilSupport
-GalilTest_LIBS += asyn motor calc sscan autosave busy
+GalilTest_LIBS += motor busy asyn calc sscan autosave
+ifdef SNCSEQ
+GalilTest_LIBS += seq pv
+endif
 GalilTest_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 #===========================

--- a/3-6/Makefile
+++ b/3-6/Makefile
@@ -1,8 +1,31 @@
-#Makefile at top of application tree
+# Makefile at top of application tree
 TOP = .
 include $(TOP)/configure/CONFIG
-DIRS := $(DIRS) $(filter-out $(DIRS), configure)
-DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Sup))
-DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
-DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocBoot))
+
+# Directories to build, any order
+DIRS += configure
+DIRS += $(wildcard *Sup)
+DIRS += $(wildcard *App)
+DIRS += $(wildcard *Top)
+DIRS += $(wildcard iocBoot)
+
+# The build order is controlled by these dependency rules:
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+
+# Any *App dirs depend on all *Sup dirs
+$(foreach dir, $(filter %App, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
+
+# Any *Top dirs depend on all *Sup and *App dirs
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
+
+# iocBoot depends on all *App dirs
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+# Add any additional dependency rules here:
+
 include $(TOP)/configure/RULES_TOP

--- a/3-6/configure/RELEASE
+++ b/3-6/configure/RELEASE
@@ -3,3 +3,10 @@
 include $(TOP)/config/GALILRELEASE
 
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
+
+# These allow developers to override the RELEASE variable settings
+# without having to modify the configure/RELEASE file itself.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../configure/RELEASE.local
+-include $(TOP)/RELEASE.local
+-include $(TOP)/configure/RELEASE.local

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SUBDIRS = 3-6
+
+.PHONY : all install uninstall distclean clean subdirs $(SUBDIRS)
+.NOTPARALLEL :
+
+all : install
+
+install : subdirs
+uninstall : subdirs
+distclean : subdirs
+clean : subdirs
+
+subdirs : $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@ $(MAKECMDGOALS)


### PR DESCRIPTION
Add support for windows builds on Appveyor using the epics-base ci-scripts. Support for travis builds would be easy to add too.